### PR TITLE
ERCC: process as separate pipeline, QC

### DIFF
--- a/ont_cDNA/QC/ERCC_functions.R
+++ b/ont_cDNA/QC/ERCC_functions.R
@@ -154,8 +154,11 @@ plot_usage_persample <- function(ERCC_classFile, ERCC_demux) {
     percentages[[sample]] <- percentage_table
     
     # Create the plot
+    percentage_table$structural_category <- factor(percentage_table$structural_category, 
+                                               levels = rev(unique(percentage_table$structural_category)))
+
     plots[[sample]] <- percentage_table %>%
-      ggplot(aes(x = chrom, y = as.numeric(perc), fill = forcats::fct_rev(structural_category))) +
+      ggplot(aes(x = chrom, y = as.numeric(perc), fill = structural_category)) +
       geom_bar(stat = "identity", color = "black", size = 0.2) +
       theme_classic() +
       labs(x = "Gene", y = "Isoform fraction (%)", title = sample) +

--- a/ont_cDNA/QC/QC_report.Rmd
+++ b/ont_cDNA/QC/QC_report.Rmd
@@ -107,13 +107,14 @@ if(isTRUE(ERCC_added)){
   ercc_stats <- read.csv(paste0(utilsDir, "ERCC_Stats.csv"))
   ercc_calculation <- merge(ercc_calculation, ercc_stats, by.x = "ERCC_ID", by.y = "ERCC.ID")
 
-  file_path <- paste0(ERCCDir, "/", list.files(ERCCDir, pattern = "RulesFilter_result_classification\\.txt$"))
+  file_path <- paste0(ERCCDir, "/", list.files(ERCCDir, pattern = "RulesFilter_result_classification\\.txt$", recursive = TRUE))
   message("Reading in ERCC file", file_path)
   ERCC_classFile <- fread(file_path, data.table = FALSE)
   ERCC_classFile <- ERCC_classFile %>% filter(filter_result == "Isoform") 
   monoexonic <- ERCC_classFile[ERCC_classFile$subcategory == "mono-exon" & ERCC_classFile$structural_category != "full-splice_match","isoform"]
   ERCC_classFile <- ERCC_classFile %>% filter(!isoform %in% monoexonic)
-  ERCC_demux <- fread(paste0(ERCCDir, "/demux_fl_count.csv"), data.table = F)
+  ERCC_demux_file <- list.files(ERCCDir, pattern = "demux_fl_count\\.csv$", recursive = TRUE, full.names = TRUE)
+  ERCC_demux <- fread(ERCC_demux_file, data.table = F)
 }
 
 ```
@@ -247,14 +248,14 @@ ggplot(dat, aes(x = as.factor(target_sequence), y = n)) +
 
 
 ```{r ERCC, fig.width = 12, fig.height = 6, echo = FALSE, fig.bottomcaption = TRUE, fig.cap="\\raggedrightFigure: number of reads aligned to each chromosome.", eval = ERCC_added}
-ERCC_alignedStats <- read_ERCC_alignedStats(ERCCDir)
+ERCC_alignedStats <- read_ERCC_alignedStats(paste0(ERCCDir,"3_minimap"))
 detectedNumERCC <- length(unique(ERCC_alignedStats$target_sequence))
 
 # tally the number of ERCC
 numDetected <- ERCC_alignedStats %>% group_by(sample) %>% tally(name = "number")
 
 # merge back with original number of reads per sample
-numDetected <- merge(demuxStats[,c("sample","num_seqs")], numDetected, by = "sample") %>% 
+numDetected <- merge(input$demuxStats[,c("sample","num_seqs")], numDetected, by = "sample") %>% 
   mutate(perc = number/num_seqs * 100)
 
 numDetectedPerSample <- ERCC_alignedStats %>% group_by(sample) %>% summarise(unique_count = n_distinct(target_sequence))
@@ -271,8 +272,6 @@ ERCC_detected <- detect_ERCC(ERCC_alignedStats)
 `r if (ERCC_added) {
   "
   We expect that the ERCC detected would depend on the amount and not on the length i.e. ERCC with the known higher amounts are more likely to be sequenced, whereas longer ERCC are as likely to be sequenced as the shorter ERCC molecules. We also expect this phenomenon to be consistent across all the samples.
-
-  ### Factors impacting detection
   "
 }`
 
@@ -308,8 +307,6 @@ pRedundant[[2]]
 
 `r if (ERCC_added) {
   "
-  #### Isoform proportions
-  
   Despite the significant number of *unique isoforms*, there should only be one or two **dominant** isoform per ERCC molecule whereby the remaining isoforms are insignificant - i.e. a *minor* isoform, defined by less than 5% of the total proportion.
   
   Below are plots of the *isoform* landscape of each ERCC molecule per sample. The number in the grey bar refers to the number of minor ERCC molecules, and the individual lines dissecting the bars refer to the proportion of the major isoform.

--- a/ont_cDNA/processing/01_source_functions.sh
+++ b/ont_cDNA/processing/01_source_functions.sh
@@ -199,12 +199,22 @@ run_minimap2(){
     samtools view -S -b $2/${name}_filtered.sam | samtools sort -o $2/${name}_filtered_sorted.bam
     samtools index $2/${name}_filtered_sorted.bam
   
-    htsbox samview -pS $2/${name}_sorted.sam > $2/${name}.paf
+    htsbox samview -pS $2/${name}.sam > $2/${name}.paf
     awk -F'\t' '{if ($6!="*") {print $0}}' $2/${name}.paf > $2/${name}.filtered.paf
     awk -F'\t' '{print $1,$6,$8+1,$2,$4-$3,($4-$3)/$2,$10,($10)/($4-$3),$5,$13,$15,$17}' $2/${name}.filtered.paf | sed -e s/"mm:i:"/""/g -e s/"in:i:"/""/g -e s/"dn:i:"/""/g | sed s/" "/"\t"/g > $2/${name}"_mappedstats.txt"
   
   fi
 
+}
+
+run_minimap2stats(){
+
+  name=$(basename $1 .fastq)
+
+  htsbox samview -pS $2/${name}.sam > $2/${name}.paf
+  awk -F'\t' '{if ($6!="*") {print $0}}' $2/${name}.paf > $2/${name}.filtered.paf
+  awk -F'\t' '{print $1,$6,$8+1,$2,$4-$3,($4-$3)/$2,$10,($10)/($4-$3),$5,$13,$15,$17}' $2/${name}.filtered.paf | sed -e s/"mm:i:"/""/g -e s/"in:i:"/""/g -e s/"dn:i:"/""/g | sed s/" "/"\t"/g > $2/${name}"_mappedstats.txt"
+  
 }
 
 

--- a/ont_cDNA/processing/2_cutadapt_minimap2_tclean.sh
+++ b/ont_cDNA/processing/2_cutadapt_minimap2_tclean.sh
@@ -49,6 +49,10 @@ elif [ "${DEMULTIPLEX_SOFTWARE}" == "Porechop" ] || [ "${SEQUENCING}" == "target
     # Run post-processing for Porechop or targeted sequencing
     post_porechop_run_cutadapt ${WKD_ROOT}/1b_demultiplex_merged/${sample}_merged.fastq ${WKD_ROOT}/2_cutadapt_merge
 
+elif [ "${ERCC}" == "TRUE" ]; then
+    # create a symlink between $WKD_ROOT/1_demultiplex and already demuxed folder (overwrites)
+    ln -sfn ${GENOME_WKD_ROOT}/2_cutadapt_merge/* "${WKD_ROOT}/2_cutadapt_merge/"
+    
 else
     # Exit with error if none of the conditions are met
     echo "Error: Invalid configuration for demultiplexing, check wiki for combinations."
@@ -57,7 +61,6 @@ fi
 
 # map combined fasta to reference genome
 run_minimap2 ${WKD_ROOT}/2_cutadapt_merge/${sample}_merged_combined.fastq ${WKD_ROOT}/3_minimap
-
 
 # run transcript clean on aligned reads
 run_transcriptclean ${WKD_ROOT}/3_minimap/${sample}_merged_combined_filtered_sorted.sam ${WKD_ROOT}/4_tclean

--- a/ont_cDNA/processing/4_QC.sh
+++ b/ont_cDNA/processing/4_QC.sh
@@ -47,7 +47,7 @@ fi
 if [ "${ERCC_WKD_ROOT}" == "NULL" ]; then
   ERCCDirParam="NULL"
 else
-  ERCCDirParam="'${ERCCDir}'"  # Quote the ERCCDir path
+  ERCCDirParam="'${ERCC_WKD_ROOT}'"  # Quote the ERCCDir path
 fi
 
 Rscript -e "rmarkdown::render('${SCRIPT_ROOT}/QC/QC_report.Rmd', output_file='${WKD_ROOT}/QC_report.html', 


### PR DESCRIPTION
- removed forcats in plotting usage (not need to install library)
- create run_minimap2stats function for when mappedStats.txt are not generated from minimap2
- create separate pipeline in 2_cutadapt_minimap2_tclean.sh for ERCC
- incorporated ERCC standards into QC Rmarkdown